### PR TITLE
Adding git to Raspbian setup dependencies

### DIFF
--- a/glob-vars.sh
+++ b/glob-vars.sh
@@ -86,3 +86,8 @@ RASPBIAN_SYSTEMD_CONF_FILE="litecoind.service" #name of the litecoind systemd sc
 #define download locations
 RASPBIAN_BASE="$SCRIPT_DL_URL/$DIST" #base directory for raspbian script files
 RASPBIAN_SYSTEMD_DL_URL="$RASPBIAN_BASE/litecoind.service" #the download location of the systemd.conf file for litecoind
+
+# Temporarily increase swap space on Raspberry Pi to allow for litecoind build
+# Value tested on RPi 3 hardware (1GB RAM)
+DESIRED_SWAP_SIZE_IN_KB="640000"
+ORIGINAL_SWAP_SIZE_IN_KB=$(sudo cat /proc/swaps | awk '{print $3}' | grep -E '[0-9]')

--- a/raspbian/raspbian-install-litecoin.sh
+++ b/raspbian/raspbian-install-litecoin.sh
@@ -53,7 +53,7 @@ echo "addnode=$selectedarray_two" >> $LITECOIND_CONF_FILE
 echo "Installing dependencies required for building Litecoin"
 sudo apt-get install autoconf libtool libssl-dev libboost-all-dev libminiupnpc-dev -y
 sudo apt-get install qt4-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev -y
-sudo apt-get install git -y
+sudo apt-get install git libevent-dev -y
 
 #setup berkleydb and other build dependencies
 echo "Setting up berkleydb"

--- a/raspbian/raspbian-install-litecoin.sh
+++ b/raspbian/raspbian-install-litecoin.sh
@@ -53,6 +53,7 @@ echo "addnode=$selectedarray_two" >> $LITECOIND_CONF_FILE
 echo "Installing dependencies required for building Litecoin"
 sudo apt-get install autoconf libtool libssl-dev libboost-all-dev libminiupnpc-dev -y
 sudo apt-get install qt4-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev -y
+sudo apt-get install git -y
 
 #setup berkleydb and other build dependencies
 echo "Setting up berkleydb"


### PR DESCRIPTION
Adding git to Raspbian setup dependencies because raspbian-install-litecoin.sh fails when executed on a Raspbian Lite image (2017-09-07-raspbian-stretch-lite) due to missing git